### PR TITLE
Update to api 24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-23.0.2
-    - android-23
+    - build-tools-24.0.3
+    - android-24
     - extra-android-m2repository
 
 script:
-  - ./gradlew clean assembleDebug --stacktrace
+  - ./gradlew clean assembleDebug testDebug --stacktrace
 
 branches:
   except:
@@ -27,4 +27,3 @@ cache:
   directories:
     - $HOME/.m2
     - $HOME/.gradle
-

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.codemonkeylabs.fpslibrary.sample"
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -23,21 +23,19 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-
     //compile against maven central repo
     //compile 'com.github.brianPlummer:tinydancer:0.0.1'
 
     //compile against local library
     compile project(':library')
 
-    compile 'com.android.support:appcompat-v7:23.2.0'
-    compile 'com.android.support:recyclerview-v7:23.2.0'
-    compile 'com.jakewharton:butterknife:7.0.1'
-    compile 'com.google.dagger:dagger:2.0.2'
+    compile deps.appcompatv7
+    compile deps.recyclerviewv7
+    compile deps.butterknife
+    compile deps.dagger
 
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.0.2'
+    annotationProcessor deps.daggerCompiler
 
-    provided 'org.glassfish:javax.annotation:10.0-b28'
+    provided deps.javaxAnnotation
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,3 +19,36 @@ allprojects {
     }
 }
 
+// Variables for entire project
+ext {
+    // SDK versions
+    minSdkVersion = 16
+    targetSdkVersion = 24
+    compileSdkVersion = 24
+    buildToolsVersion = "24.0.3"
+    sourceCompatibilityVersion = JavaVersion.VERSION_1_7
+    targetCompatibilityVersion = JavaVersion.VERSION_1_7
+
+    // Common versions
+    supportLibraryVersion = "24.2.1"
+    butterKnifeVersion = "7.0.1"
+    daggerVersion = "2.0.2"
+}
+
+// Dependencies
+ext.deps = [
+        // compile
+        appcompatv7    : "com.android.support:appcompat-v7:${supportLibraryVersion}",
+        recyclerviewv7 : "com.android.support:recyclerview-v7:${supportLibraryVersion}",
+        butterknife    : "com.jakewharton:butterknife:${butterKnifeVersion}",
+        dagger         : "com.google.dagger:dagger:${daggerVersion}",
+
+        // annotationProcessor
+        daggerCompiler : "com.google.dagger:dagger-compiler:${daggerVersion}",
+
+        // provided
+        javaxAnnotation: "org.glassfish:javax.annotation:10.0-b28",
+
+        // testCompile
+        junit          : "junit:junit:4.12"
+]

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 //apply from: 'maven-push.gradle'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -17,16 +17,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
-    sourceSets {
-        androidTest {
-            setRoot('src/test')
-        }
-    }
-
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
+    testCompile deps.junit
 }


### PR DESCRIPTION
- Even though API 25 is out, lets just update one step at a time, starting with API 24
- Use a map to store dependencies
- Use ext properties for common versions